### PR TITLE
#393 - Getting AssetDownloadServlet's max size configuration

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/impl/DownloadImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/impl/DownloadImpl.java
@@ -23,8 +23,6 @@ import com.adobe.aem.commons.assetshare.components.actions.ActionHelper;
 import com.adobe.aem.commons.assetshare.components.actions.AssetDownloadHelper;
 import com.adobe.aem.commons.assetshare.components.actions.download.Download;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
-import com.day.cq.dam.api.DamConstants;
-import com.day.cq.dam.api.jobs.AssetDownloadService;
 import com.day.cq.dam.commons.util.UIHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -64,7 +62,7 @@ public class DownloadImpl implements Download {
     @Required
     protected ActionHelper actionHelper;
 
-    
+
     @OSGiService
     @Required
     protected AssetDownloadHelper assetDownloadHelper;
@@ -84,14 +82,15 @@ public class DownloadImpl implements Download {
     @PostConstruct
     protected void init() {
         assets = actionHelper.getAssetsFromQueryParameter(request, "path");
+
         if (assets.isEmpty()) {
             assets = actionHelper.getPlaceholderAsset(request);
         } else {
             this.maxContentSize = assetDownloadHelper.getMaxContentSizeLimit();
-            log.info("Max Content Size: " + this.maxContentSize);
-            
+            log.debug("Max allowed content size (in bytes) [ {} ]", this.maxContentSize);
+
             this.downloadContentSize = assetDownloadHelper.computeAssetDownloadSize(assets, request.getResource());
-            log.info("Download content size: " + this.downloadContentSize);
+            log.debug("Requested download content size (in bytes) [ {} ]", this.downloadContentSize);
         }
     }
 
@@ -105,10 +104,9 @@ public class DownloadImpl implements Download {
 
     @Override
     public boolean isMaxContentSize() {
-        if(maxContentSize != null && maxContentSize > 0 &&  maxContentSize < downloadContentSize) {
-            return true;
-        }
-        return false;
+        return maxContentSize != null &&
+                maxContentSize > 0 &&
+                maxContentSize < downloadContentSize;
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/impl/AssetDownloadHelperImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/impl/AssetDownloadHelperImpl.java
@@ -1,17 +1,11 @@
 package com.adobe.aem.commons.assetshare.components.actions.impl;
 
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Dictionary;
-import java.util.HashSet;
-import java.util.Set;
 import com.adobe.aem.commons.assetshare.components.actions.AssetDownloadHelper;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.day.cq.dam.api.jobs.AssetDownloadService;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
@@ -19,11 +13,17 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.HashSet;
+import java.util.Set;
+
 @Component
 public class AssetDownloadHelperImpl implements AssetDownloadHelper {
-
     private static final Logger log = LoggerFactory.getLogger(AssetDownloadHelperImpl.class);
-    private static final String ASSET_DOWNLOAD_PID = "com.day.cq.dam.core.impl.servlet.AssetDownloadServlet";
+
+    private static final String ASSET_DOWNLOAD_SERVLET_PID = "com.day.cq.dam.core.impl.servlet.AssetDownloadServlet";
     private static final String MAX_SIZE_PROPERTY = "asset.download.prezip.maxcontentsize";
 
     @Reference
@@ -34,49 +34,52 @@ public class AssetDownloadHelperImpl implements AssetDownloadHelper {
 
     @Override
     public long getMaxContentSizeLimit() {
-        return getProperty(ASSET_DOWNLOAD_PID, MAX_SIZE_PROPERTY);
-    }
-
-    private long getProperty(final String pid, final String property) {
         try {
-            Configuration conf = configAdmin.getConfiguration(pid);
+            Configuration[] configurations = configAdmin.listConfigurations(
+                    "(service.pid=" + ASSET_DOWNLOAD_SERVLET_PID + ")");
 
-            @SuppressWarnings("unchecked")
-            Dictionary<String, Object> props = conf.getProperties();
-            
-            if (props != null) {
-                return PropertiesUtil.toLong(props.get(property), -1L);
+            if (configurations != null && configurations.length == 1) {
+                @SuppressWarnings("unchecked") final Dictionary<String, Object> osgiConfigurationProperties = configurations[0].getProperties();
+
+                if (osgiConfigurationProperties != null) {
+                    return PropertiesUtil.toLong(osgiConfigurationProperties.get(MAX_SIZE_PROPERTY), -1L);
+                } else{
+                    log.debug("No OSGi configuration properties could be found for service.pid [ {} ]", ASSET_DOWNLOAD_SERVLET_PID);
+                }
+            } else {
+                log.debug("A non-unary number of OSGi configuration could be found for service.pid [ {} ]", ASSET_DOWNLOAD_SERVLET_PID);
             }
-        } catch (IOException e) {
-            log.error("Could not get property", e);
+        } catch (IOException | InvalidSyntaxException e) {
+            log.error("Could not get max content size property for AEM's Asset Download Servlet", e);
         }
+
         return -1L;
     }
 
     @Override
     public long computeAssetDownloadSize(Collection<AssetModel> assets, Resource requestResource) {
-        Set<Resource> assetDownloadRequestPathsSet = new HashSet<Resource>();
+        final Set<Resource> assetDownloadRequestPathsSet = new HashSet<Resource>();
 
-        for (AssetModel asset : assets) {
+        for (final AssetModel asset : assets) {
             assetDownloadRequestPathsSet.add(asset.getResource());
         }
 
-        //Use AssetDownloadService to compute the prezip size based on list of assets
-        AssetDownloadService.AssetDownloadParams preZipComputationParams = new AssetDownloadService.AssetDownloadParams(
-            requestResource,
-            assetDownloadRequestPathsSet, 
-            true, 
-            true, 
-            true,
-            null, 
-            null,
-            null,
-            "assests.zip", 
-            null,
-            false, 
-            null, 
-            null);
+        // Use AssetDownloadService to compute the pre-zip size based on list of assets
+        final AssetDownloadService.AssetDownloadParams preZipComputationParams = new AssetDownloadService.AssetDownloadParams(
+                requestResource,
+                assetDownloadRequestPathsSet,
+                true,
+                true,
+                true,
+                null,
+                null,
+                null,
+                "assets.zip", // downloadName doesn't matter
+                null,
+                false,
+                null,
+                null);
+
         return assetDownloadService.computeAssetDownloadSize(preZipComputationParams);
     }
-
 }


### PR DESCRIPTION
I think the problem was the `getConfiguration(..)` API would create a new configuration if one did not exist (https://osgi.org/javadoc/r6/cmpn/org/osgi/service/cm/ConfigurationAdmin.html#getConfiguration(java.lang.String))
.. So it seemed like the code (when run on AEM Author at least) was creating a new configuration when the code was executed. the `listConfigurations(...)` looks like a read-only operation per the javadocs, so doesn't alter the state of the OSGi container.

I am a bit confused by this change in the product - as I didn't see a maxcontentsize OSGi config in the 
AEM Author servlet's OSGi properties - is that correct? Is there no limit? Or a hardcoded limit in their Javacode? It seems like the max-sizes should be in sync across author/publish? If it can take down Pub then it can take down Author; and it doesn't take a malicious act to do so - just someone that wants a bunch of files that happen to be big.

One other thing I didn't check in this PR, was what happens if a new OSGi configuration is provided; right now there is code to guard to ensure only 1 configuration exists - and if it is non-unary, treat it as an error condition (-1 size)... I think that's right? but not sure that's a correct assumption.